### PR TITLE
Use Docker API for logs.

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -21,15 +21,15 @@ jobs:
       changed: ${{ steps.changed_addons.outputs.changed }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6.0.0
 
       - name: Get changed files
         id: changed_files
-        uses: jitterbit/get-changed-files@v1
+        uses: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42
 
       - name: Find add-on directories
         id: addons
-        uses: home-assistant/actions/helpers/find-addons@master
+        uses: home-assistant/actions/helpers/find-addons@4b258cf2bf1668d8e0adcb6b2be96b6cda36f42f #v1.0.0
 
       - name: Get changed add-ons
         id: changed_addons
@@ -68,11 +68,11 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6.0.0
 
       - name: Get information
         id: info
-        uses: home-assistant/actions/helpers/info@master
+        uses: home-assistant/actions/helpers/info@4b258cf2bf1668d8e0adcb6b2be96b6cda36f42f #v1.0.0
         with:
           path: "./${{ matrix.addon }}"
 
@@ -92,7 +92,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: env.BUILD_ARGS != '--test'
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef #v3.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -100,7 +100,7 @@ jobs:
 
       - name: Build ${{ matrix.addon }} add-on
         if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@2024.08.2
+        uses: home-assistant/builder@21bc64d76dad7a5184c67826aab41c6b6f89023a #2025.11.0
         with:
           args: |
             ${{ env.BUILD_ARGS }} \

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -82,13 +82,15 @@ jobs:
           if [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
              echo "build_arch=true" >> $GITHUB_OUTPUT;
              echo "image=$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
-             if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
+             if [[ -z "${GITHUB_HEAD_REF}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
                  echo "BUILD_ARGS=" >> $GITHUB_ENV;
              fi
            else
              echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
              echo "build_arch=false" >> $GITHUB_OUTPUT;
           fi
+         env:
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
 
       - name: Login to GitHub Container Registry
         if: env.BUILD_ARGS != '--test'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,11 +18,11 @@ jobs:
       addons: ${{ steps.addons.outputs.addons_list }}
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6.0.0
 
       - name: 🔍 Find add-on directories
         id: addons
-        uses: home-assistant/actions/helpers/find-addons@master
+        uses: home-assistant/actions/helpers/find-addons@4b258cf2bf1668d8e0adcb6b2be96b6cda36f42f #v1.0.0
 
   lint:
     name: Lint add-on ${{ matrix.path }}
@@ -33,9 +33,9 @@ jobs:
         path: ${{ fromJson(needs.find.outputs.addons) }}
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6.0.0
 
       - name: 🚀 Run Home Assistant Add-on Lint
-        uses: frenck/action-addon-linter@v2.16
+        uses: frenck/action-addon-linter@f995494fd84fae6310d23617e66d0e37de4f14eb #v2.21.0
         with:
           path: "./${{ matrix.path }}"

--- a/grafana_cloud/config.yaml
+++ b/grafana_cloud/config.yaml
@@ -28,3 +28,4 @@ ports_description:
   80/tcp: "Debug UI"
 webui: "http://[HOST]:[PORT:80]/"
 image: "ghcr.io/grafana/hass-addon-grafana-cloud-{arch}"
+docker_api: true

--- a/grafana_cloud/rootfs/config.alloy
+++ b/grafana_cloud/rootfs/config.alloy
@@ -36,15 +36,26 @@ prometheus.scrape "alloy" {
   scrape_interval = env("SCRAPE_INTERVAL")
 }
 
-loki.source.file "homeassistant" {
+discovery.docker "linux" {
+  host = "unix:///var/run/docker.sock"
+}
+
+discovery.relabel "logs_integrations_docker" {
+  targets = []
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex = "/(.*)"
+    target_label = "service_name"
+  }
+}
+
+loki.source.docker "default" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.docker.linux.targets
+  labels     = {"platform" = "docker"}
+  relabel_rules = discovery.relabel.logs_integrations_docker.rules
   forward_to = [loki.process.homeassistant.receiver]
-  targets = [
-    {
-      "__path__" = "/homeassistant/home-assistant.log",
-      "instance" = env("INSTANCE_NAME"),
-      "component" = "homeassistant",
-    },
-  ]
 }
 
 loki.process "homeassistant" {


### PR DESCRIPTION
Since 2025.11, Home Assistant no longer writes its logs to home-assistant.log (see https://github.com/home-assistant/core/pull/146675).

Instead, this uses the Docker API to fetch the logs.  Bonus is this also fetched logs for the other addons.