### PR TITLE
grafana_cloud: declare optional syslog ports (5514/udp, 6514/tcp)

### DIFF
--- a/grafana_cloud/config.yaml
+++ b/grafana_cloud/config.yaml
@@ -24,7 +24,11 @@ map:
   - addon_config:rw
 ports:
   80/tcp: null
+  5514/udp: null
+  6514/tcp: null
 ports_description:
   80/tcp: "Debug UI"
+  5514/udp: "Syslog UDP receiver (e.g. loki.source.syslog)"
+  6514/tcp: "Syslog TCP/TLS receiver (e.g. loki.source.syslog)"
 webui: "http://[HOST]:[PORT:80]/"
 image: "ghcr.io/grafana/hass-addon-grafana-cloud-{arch}"


### PR DESCRIPTION
## Summary

This addon bundles Alloy, which natively supports `loki.source.syslog` on both UDP and TCP. However, the receiver can only accept external traffic if the syslog ports are advertised in the addon manifest so HA Supervisor publishes them to the host network namespace. Currently only `80/tcp` is declared.

This PR adds two commonly-used syslog ports (`5514/udp` and `6514/tcp`), both defaulting to `null` so they have no effect unless a user explicitly binds a host port via the addon's Network configuration UI.

## Why these ports (and why not 514)

- `5514/udp` — de-facto unprivileged alternative to 514/udp for RFC5424 / CEF syslog.
- `6514/tcp` — RFC5425-aligned port for syslog-over-TLS / TCP.

The canonical `514/udp` is privileged and not included (addons run unprivileged and can't bind <1024 without extra capabilities). Users who need other ports can add them via a small follow-up.

## Behavior change

- Default install (ports unbound): **no change**. The addon's listeners don't exist in `config.alloy` so the Alloy process doesn't bind them, and the Supervisor side doesn't publish host ports. Zero runtime impact.
- Users who configure `loki.source.syslog` in `config.alloy` + bind a host port in the addon's Network UI: Alloy accepts external syslog on the bound port, without needing a separate syslog-ng translator addon.

## Motivation

For users running a UniFi controller, ISP router, firewalls, IoT hubs, or similar equipment that emits syslog/CEF, Alloy's native receiver replaces what today needs a separate syslog-ng-style translator addon (extra process, extra memory, UDP→TCP translation overhead). This manifest tweak is the minimum change to make that direct-ingest pattern work with this addon.

## Test plan

- [x] Addon linter passes (frenck/action-addon-linter)
- [x] Addon starts with the new manifest and default options; no new listeners bound when `config.alloy` doesn't reference `loki.source.syslog`
- [x] With `loki.source.syslog` configured + 5514/udp host-bound, UDP CEF from an external UniFi controller reaches the Alloy receiver and is written to the configured Loki endpoint

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)