### PR TITLE
Update to Alloy v1.19.2 and migrate to new HA builder

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -20,7 +20,7 @@ jobs:
       changed: ${{ steps.changed_addons.outputs.changed }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Get changed files
         id: changed_files
@@ -35,7 +35,7 @@ jobs:
 
       - name: Find add-on directories
         id: addons
-        uses: home-assistant/actions/helpers/find-addons@master
+        uses: home-assistant/actions/helpers/find-addons@a7c616ce81ccda50150bf1595786c71b1883fabb # master
 
       - name: Get changed add-ons
         id: changed_addons
@@ -81,11 +81,11 @@ jobs:
       url: ${{ steps.normalize.outputs.url }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Get add-on information
         id: info
-        uses: home-assistant/actions/helpers/info@master
+        uses: home-assistant/actions/helpers/info@a7c616ce81ccda50150bf1595786c71b1883fabb # master
         with:
           path: "./${{ matrix.addon }}"
 
@@ -108,7 +108,7 @@ jobs:
 
       - name: Prepare build matrix
         id: matrix
-        uses: home-assistant/builder/actions/prepare-multi-arch-matrix@2026.06.0
+        uses: home-assistant/builder/actions/prepare-multi-arch-matrix@4de35182ce1e329181bffcbcc84d33db5e2c7e10 # 2026.06.0
         with:
           architectures: ${{ steps.info.outputs.architectures }}
           image-name: ${{ steps.normalize.outputs.image_name }}
@@ -127,10 +127,10 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.build_matrix) }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Build image
-        uses: home-assistant/builder/actions/build-image@2026.06.0
+        uses: home-assistant/builder/actions/build-image@4de35182ce1e329181bffcbcc84d33db5e2c7e10 # 2026.06.0
         with:
           arch: ${{ matrix.arch }}
           container-registry-password: ${{ secrets.GITHUB_TOKEN }}
@@ -157,11 +157,11 @@ jobs:
       packages: write
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Get add-on information
         id: info
-        uses: home-assistant/actions/helpers/info@master
+        uses: home-assistant/actions/helpers/info@a7c616ce81ccda50150bf1595786c71b1883fabb # master
         with:
           path: "./grafana_cloud"
 
@@ -173,7 +173,7 @@ jobs:
           echo "registry_prefix=${image%/*}" >> "$GITHUB_OUTPUT"
 
       - name: Publish multi-arch manifest
-        uses: home-assistant/builder/actions/publish-multi-arch-manifest@2026.06.0
+        uses: home-assistant/builder/actions/publish-multi-arch-manifest@4de35182ce1e329181bffcbcc84d33db5e2c7e10 # 2026.06.0
         with:
           architectures: ${{ steps.info.outputs.architectures }}
           container-registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -1,9 +1,5 @@
 name: Builder
 
-env:
-  BUILD_ARGS: "--test"
-  MONITORED_FILES: "build.yaml config.yaml Dockerfile rootfs"
-
 on:
   push:
     branches:
@@ -12,20 +8,30 @@ on:
     branches:
       - main
 
+env:
+  MONITORED_FILES: "build.yaml config.yaml Dockerfile rootfs"
+
 jobs:
   init:
-    runs-on: ubuntu-latest
     name: Initialize builds
+    runs-on: ubuntu-latest
     outputs:
       changed_addons: ${{ steps.changed_addons.outputs.addons }}
       changed: ${{ steps.changed_addons.outputs.changed }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7.0.0
 
       - name: Get changed files
         id: changed_files
-        uses: jitterbit/get-changed-files@v1
+        if: github.event_name == 'pull_request'
+        run: |
+          changed=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
+          echo "all<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$changed" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Find add-on directories
         id: addons
@@ -36,13 +42,15 @@ jobs:
         run: |
           declare -a changed_addons
           for addon in ${{ steps.addons.outputs.addons }}; do
-            if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon ]]; then
+            if [[ "${{ github.event_name }}" == "push" ]]; then
+              changed_addons+=("\"${addon}\",");
+            elif [[ "${{ steps.changed_files.outputs.all }}" =~ $addon ]]; then
               for file in ${{ env.MONITORED_FILES }}; do
-                  if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon/$file ]]; then
-                    if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
-                      changed_addons+=("\"${addon}\",");
-                    fi
+                if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon/$file ]]; then
+                  if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
+                    changed_addons+=("\"${addon}\",");
                   fi
+                fi
               done
             fi
           done
@@ -56,56 +64,121 @@ jobs:
           else
             echo "No add-on had any monitored files changed (${{ env.MONITORED_FILES }})";
           fi
-  build:
+
+  prepare:
+    name: Prepare ${{ matrix.addon }} build
     needs: init
-    runs-on: ubuntu-latest
     if: needs.init.outputs.changed == 'true'
-    name: Build ${{ matrix.arch }} ${{ matrix.addon }} add-on
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
-        arch: ["aarch64", "amd64", "armhf", "armv7", "i386"]
-
+    outputs:
+      build_matrix: ${{ steps.matrix.outputs.matrix }}
+      version: ${{ steps.normalize.outputs.version }}
+      name: ${{ steps.normalize.outputs.name }}
+      description: ${{ steps.normalize.outputs.description }}
+      url: ${{ steps.normalize.outputs.url }}
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4.1.7
+      - name: Check out the repository
+        uses: actions/checkout@v7.0.0
 
-      - name: Get information
+      - name: Get add-on information
         id: info
         uses: home-assistant/actions/helpers/info@master
         with:
           path: "./${{ matrix.addon }}"
 
-      - name: Check if add-on should be built
-        id: check
+      - name: Normalize add-on information
+        id: normalize
         run: |
-          if [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
-             echo "build_arch=true" >> $GITHUB_OUTPUT;
-             echo "image=$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
-             if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
-                 echo "BUILD_ARGS=" >> $GITHUB_ENV;
-             fi
-           else
-             echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
-             echo "build_arch=false" >> $GITHUB_OUTPUT;
+          image=${{ steps.info.outputs.image }}
+          echo "image_name=${image##*/}" >> "$GITHUB_OUTPUT"
+          echo "registry_prefix=${image%/*}" >> "$GITHUB_OUTPUT"
+          version=${{ steps.info.outputs.version }}
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          name=${{ steps.info.outputs.name }}
+          echo "name=${name}" >> "$GITHUB_OUTPUT"
+          description=${{ steps.info.outputs.description }}
+          echo "description=${description}" >> "$GITHUB_OUTPUT"
+          url=${{ steps.info.outputs.url }}
+          if [[ -n "$url" && "$url" != "null" ]]; then
+            echo "url=${url}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Login to GitHub Container Registry
-        if: env.BUILD_ARGS != '--test'
-        uses: docker/login-action@v3.3.0
+      - name: Prepare build matrix
+        id: matrix
+        uses: home-assistant/builder/actions/prepare-multi-arch-matrix@2026.06.0
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          architectures: ${{ steps.info.outputs.architectures }}
+          image-name: ${{ steps.normalize.outputs.image_name }}
+          registry-prefix: ${{ steps.normalize.outputs.registry_prefix }}
 
-      - name: Build ${{ matrix.addon }} add-on
-        if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@2024.08.2
+  build:
+    name: Build ${{ matrix.arch }} image
+    needs: prepare
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.build_matrix) }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Build image
+        uses: home-assistant/builder/actions/build-image@2026.06.0
         with:
-          args: |
-            ${{ env.BUILD_ARGS }} \
-            --${{ matrix.arch }} \
-            --target /data/${{ matrix.addon }} \
-            --image "${{ steps.check.outputs.image }}" \
-            --docker-hub "ghcr.io/${{ github.repository_owner }}" \
-            --addon
+          arch: ${{ matrix.arch }}
+          container-registry-password: ${{ secrets.GITHUB_TOKEN }}
+          context: "./grafana_cloud"
+          image: ${{ matrix.image }}
+          image-tags: |
+            ${{ needs.prepare.outputs.version }}
+            latest
+          labels: |
+            io.hass.type=addon
+            io.hass.name=${{ needs.prepare.outputs.name }}
+            io.hass.description=${{ needs.prepare.outputs.description }}
+            ${{ needs.prepare.outputs.url && format('io.hass.url={0}', needs.prepare.outputs.url) || '' }}
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'true' || 'false' }}
+          version: ${{ needs.prepare.outputs.version }}
+
+  manifest:
+    name: Publish multi-arch manifest
+    needs: [prepare, build]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      packages: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Get add-on information
+        id: info
+        uses: home-assistant/actions/helpers/info@master
+        with:
+          path: "./grafana_cloud"
+
+      - name: Normalize add-on information
+        id: normalize
+        run: |
+          image=${{ steps.info.outputs.image }}
+          echo "image_name=${image##*/}" >> "$GITHUB_OUTPUT"
+          echo "registry_prefix=${image%/*}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish multi-arch manifest
+        uses: home-assistant/builder/actions/publish-multi-arch-manifest@2026.06.0
+        with:
+          architectures: ${{ steps.info.outputs.architectures }}
+          container-registry-password: ${{ secrets.GITHUB_TOKEN }}
+          image-name: ${{ steps.normalize.outputs.image_name }}
+          image-tags: |
+            ${{ needs.prepare.outputs.version }}
+            latest
+          registry-prefix: ${{ steps.normalize.outputs.registry_prefix }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,11 +18,11 @@ jobs:
       addons: ${{ steps.addons.outputs.addons_list }}
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Find add-on directories
         id: addons
-        uses: home-assistant/actions/helpers/find-addons@master
+        uses: home-assistant/actions/helpers/find-addons@a7c616ce81ccda50150bf1595786c71b1883fabb # master
 
   lint:
     name: Lint add-on ${{ matrix.path }}
@@ -33,9 +33,9 @@ jobs:
         path: ${{ fromJson(needs.find.outputs.addons) }}
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run Home Assistant Add-on Lint
-        uses: frenck/action-addon-linter@v2.21
+        uses: frenck/action-addon-linter@f995494fd84fae6310d23617e66d0e37de4f14eb # v2.21.0
         with:
           path: "./${{ matrix.path }}"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,10 +17,10 @@ jobs:
     outputs:
       addons: ${{ steps.addons.outputs.addons_list }}
     steps:
-      - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v4.1.7
+      - name: Check out code from GitHub
+        uses: actions/checkout@v7.0.0
 
-      - name: 🔍 Find add-on directories
+      - name: Find add-on directories
         id: addons
         uses: home-assistant/actions/helpers/find-addons@master
 
@@ -32,10 +32,10 @@ jobs:
       matrix:
         path: ${{ fromJson(needs.find.outputs.addons) }}
     steps:
-      - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v4.1.7
+      - name: Check out code from GitHub
+        uses: actions/checkout@v7.0.0
 
-      - name: 🚀 Run Home Assistant Add-on Lint
-        uses: frenck/action-addon-linter@v2.16
+      - name: Run Home Assistant Add-on Lint
+        uses: frenck/action-addon-linter@v2.21
         with:
           path: "./${{ matrix.path }}"

--- a/grafana_cloud/CHANGELOG.md
+++ b/grafana_cloud/CHANGELOG.md
@@ -1,5 +1,13 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 0.2.0
+
+- Update to Alloy v1.19.2
+- Update to addon base 3.24
+- Update alloy-modules to v0.2.11
+- Migrate to multi-arch container images
+- Migrate CI to new HA builder actions
+
 ## 0.1.2
 
 - Support providing custom config.alloy file

--- a/grafana_cloud/Dockerfile
+++ b/grafana_cloud/Dockerfile
@@ -1,7 +1,7 @@
-ARG BUILD_FROM
-FROM $BUILD_FROM
+FROM ghcr.io/home-assistant/base:3.24
 
-ARG ALLOY_VERSION BUILD_ARCH
+ARG ALLOY_VERSION="v1.19.2"
+ARG BUILD_ARCH
 RUN apk --update add libc6-compat && rm -rf /var/cache/apk/*
 
 RUN cd /tmp && \
@@ -9,5 +9,11 @@ RUN cd /tmp && \
     unzip alloy.zip && mv alloy-linux-* /usr/bin/grafana-alloy && \
     rm alloy.zip
 
-# Copy files for addon
 COPY rootfs /
+
+LABEL \
+    org.opencontainers.image.title="Home Assistant Add-on: Grafana Cloud" \
+    org.opencontainers.image.description="Grafana Cloud Addon." \
+    org.opencontainers.image.source="https://github.com/grafana/home-assistant-addons" \
+    org.opencontainers.image.licenses="Apache License 2.0" \
+    org.opencontainers.image.vendor="Grafana Labs"

--- a/grafana_cloud/Dockerfile
+++ b/grafana_cloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/home-assistant/base:3.24
+FROM ghcr.io/home-assistant/base:3.24@sha256:93ef607824e3f27e868f11b10938283a98bf880ed57bcf8eaa81c6c2d521f6f5
 
 ARG ALLOY_VERSION="v1.19.2"
 ARG BUILD_ARCH

--- a/grafana_cloud/build.yaml
+++ b/grafana_cloud/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  amd64: "ghcr.io/home-assistant/amd64-base:3.21"
-  aarch64: "ghcr.io/home-assistant/aarch64-base:3.21"
+  amd64: "ghcr.io/home-assistant/amd64-base:3.24"
+  aarch64: "ghcr.io/home-assistant/aarch64-base:3.24"
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Grafana Cloud"
   org.opencontainers.image.description: "Grafana Cloud Addon."
@@ -8,4 +8,4 @@ labels:
   org.opencontainers.image.licenses: "Apache License 2.0"
   org.opencontainers.image.vendor: "Grafana Labs"
 args:
-  ALLOY_VERSION: "v1.6.0"
+  ALLOY_VERSION: "v1.19.2"

--- a/grafana_cloud/build.yaml
+++ b/grafana_cloud/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  amd64: "ghcr.io/home-assistant/amd64-base:3.24"
-  aarch64: "ghcr.io/home-assistant/aarch64-base:3.24"
+  amd64: "ghcr.io/home-assistant/amd64-base:3.24@sha256:db83d263152a02d6daf3415a73132b2386f43a03a9c248bdaabe047b067c8eea"
+  aarch64: "ghcr.io/home-assistant/aarch64-base:3.24@sha256:265232fe91fb4271f75f17ebd4bb0749ab24fc8a64d8db38ddaccd460e9580ee"
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Grafana Cloud"
   org.opencontainers.image.description: "Grafana Cloud Addon."

--- a/grafana_cloud/config.yaml
+++ b/grafana_cloud/config.yaml
@@ -1,6 +1,6 @@
 name: "Grafana Cloud"
 description: "Send metrics & logs to Grafana Cloud"
-version: "0.1.2"
+version: "0.2.0"
 slug: "grafana_cloud"
 init: false
 arch:
@@ -27,4 +27,4 @@ ports:
 ports_description:
   80/tcp: "Debug UI"
 webui: "http://[HOST]:[PORT:80]/"
-image: "ghcr.io/grafana/hass-addon-grafana-cloud-{arch}"
+image: "ghcr.io/grafana/hass-addon-grafana-cloud"

--- a/grafana_cloud/rootfs/config.alloy
+++ b/grafana_cloud/rootfs/config.alloy
@@ -1,7 +1,7 @@
 import.git "grafana_cloud" {
   repository = "https://github.com/grafana/alloy-modules.git"
   path = "modules/cloud/grafana/cloud/module.alloy"
-  revision = "v0.2.11"
+  revision = "9c838a1fd98962edf80393cf5f5f94bbb416ecc1" # v0.2.11
   pull_frequency = "0s"
 }
 

--- a/grafana_cloud/rootfs/config.alloy
+++ b/grafana_cloud/rootfs/config.alloy
@@ -1,7 +1,7 @@
 import.git "grafana_cloud" {
   repository = "https://github.com/grafana/alloy-modules.git"
   path = "modules/cloud/grafana/cloud/module.alloy"
-  revision = "021e920"
+  revision = "v0.2.11"
   pull_frequency = "0s"
 }
 


### PR DESCRIPTION
## Summary

- Bump **Alloy** from v1.6.0 to v1.19.2
- Bump **HA base image** from 3.21 to 3.24
- Update **alloy-modules** from commit `021e920` to tag `v0.2.11`
- Migrate CI from deprecated `home-assistant/builder` action to new composable actions (`prepare-multi-arch-matrix`, `build-image`, `publish-multi-arch-manifest`)
- Switch to generic **multi-arch image naming** (drop `{arch}` suffix from `config.yaml` image)
- Update `actions/checkout` to v7, `frenck/action-addon-linter` to v2.21
- Make Dockerfile self-contained per [HA builder migration guide](https://developers.home-assistant.io/blog/2026/04/02/builder-migration/)

## Why

The `home-assistant/builder` action is [deprecated since 2026.03.0](https://github.com/home-assistant/builder?tab=readme-ov-file#legacy-home-assistantbuilder-action) and will be removed, which would break CI. Alloy v1.6.0 is 13 minor versions behind current. All GitHub Actions dependencies were stale.

## Test plan

- [x] CI lint passes
- [x] CI build completes for both amd64 and aarch64
- [ ] After merge, verify published images at `ghcr.io/grafana/hass-addon-grafana-cloud`

## Notes

Supersedes open renovate/dependabot PRs #38, #39, #40, #41, #43, #44, and older dependabot PRs. Those can be closed after merge.

`build.yaml` is retained for Supervisor local-build backward compatibility per the migration guide.