### PR TITLE
Fix alloy binary missing execute permission after unzip

### DIFF
--- a/grafana_cloud/CHANGELOG.md
+++ b/grafana_cloud/CHANGELOG.md
@@ -1,5 +1,9 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 0.2.1
+
+- Fix alloy binary missing execute permission after unzip
+
 ## 0.2.0
 
 - Update to Alloy v1.19.2

--- a/grafana_cloud/Dockerfile
+++ b/grafana_cloud/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --update add libc6-compat && rm -rf /var/cache/apk/*
 
 RUN cd /tmp && \
     curl -sSLf -o alloy.zip "https://github.com/grafana/alloy/releases/download/${ALLOY_VERSION}/alloy-linux-${BUILD_ARCH//aarch64/arm64}.zip" && \
-    unzip alloy.zip && mv alloy-linux-* /usr/bin/grafana-alloy && \
+    unzip alloy.zip && mv alloy-linux-* /usr/bin/grafana-alloy && chmod +x /usr/bin/grafana-alloy && \
     rm alloy.zip
 
 COPY rootfs /

--- a/grafana_cloud/config.yaml
+++ b/grafana_cloud/config.yaml
@@ -1,6 +1,6 @@
 name: "Grafana Cloud"
 description: "Send metrics & logs to Grafana Cloud"
-version: "0.2.0"
+version: "0.2.1"
 slug: "grafana_cloud"
 init: false
 arch:


### PR DESCRIPTION
## Problem

The `unzip` command does not preserve the execute bit on the extracted Alloy binary, causing `Permission denied` at addon startup:

```
./run: line 20: /usr/bin/grafana-alloy: Permission denied
```

## Solution

Add `chmod +x /usr/bin/grafana-alloy` after extracting the binary in the Dockerfile.

Bumps addon version to 0.2.1.