### PR TITLE
Fix Alloy config comment syntax and addon linter failure

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Check out code from GitHub
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Validate Alloy config syntax
+      - name: Validate Alloy config
         env:
           ADDON: ${{ matrix.path }}
         run: |
@@ -69,4 +69,4 @@ jobs:
 
           echo "Validating ${config} against Alloy ${version}"
           docker run --rm -v "${PWD}/${config}:/config.alloy:ro" \
-            "grafana/alloy:${version}" fmt /config.alloy > /dev/null
+            "grafana/alloy:${version}" validate /config.alloy

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,3 +39,34 @@ jobs:
         uses: frenck/action-addon-linter@f995494fd84fae6310d23617e66d0e37de4f14eb # v2.21.0
         with:
           path: "./${{ matrix.path }}"
+
+  alloy:
+    name: Validate Alloy config ${{ matrix.path }}
+    runs-on: ubuntu-latest
+    needs: find
+    strategy:
+      matrix:
+        path: ${{ fromJson(needs.find.outputs.addons) }}
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Validate Alloy config syntax
+        env:
+          ADDON: ${{ matrix.path }}
+        run: |
+          config="${ADDON}/rootfs/config.alloy"
+          if [[ ! -f "${config}" ]]; then
+            echo "No Alloy config for ${ADDON}, nothing to validate"
+            exit 0
+          fi
+
+          version=$(sed -n 's/^ARG ALLOY_VERSION="\(.*\)"$/\1/p' "${ADDON}/Dockerfile")
+          if [[ -z "${version}" ]]; then
+            echo "::error file=${ADDON}/Dockerfile::Could not determine ALLOY_VERSION"
+            exit 1
+          fi
+
+          echo "Validating ${config} against Alloy ${version}"
+          docker run --rm -v "${PWD}/${config}:/config.alloy:ro" \
+            "grafana/alloy:${version}" fmt /config.alloy > /dev/null

--- a/grafana_cloud/CHANGELOG.md
+++ b/grafana_cloud/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix Alloy config comment syntax preventing startup
 - Remove digest pins from build.yaml to satisfy addon linter schema
+- Replace deprecated env() with sys.env() in config.alloy
 
 ## 0.2.1
 

--- a/grafana_cloud/CHANGELOG.md
+++ b/grafana_cloud/CHANGELOG.md
@@ -1,5 +1,10 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 0.2.2
+
+- Fix Alloy config comment syntax preventing startup
+- Remove digest pins from build.yaml to satisfy addon linter schema
+
 ## 0.2.1
 
 - Fix alloy binary missing execute permission after unzip

--- a/grafana_cloud/build.yaml
+++ b/grafana_cloud/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  amd64: "ghcr.io/home-assistant/amd64-base:3.24@sha256:db83d263152a02d6daf3415a73132b2386f43a03a9c248bdaabe047b067c8eea"
-  aarch64: "ghcr.io/home-assistant/aarch64-base:3.24@sha256:265232fe91fb4271f75f17ebd4bb0749ab24fc8a64d8db38ddaccd460e9580ee"
+  amd64: "ghcr.io/home-assistant/amd64-base:3.24"
+  aarch64: "ghcr.io/home-assistant/aarch64-base:3.24"
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Grafana Cloud"
   org.opencontainers.image.description: "Grafana Cloud Addon."

--- a/grafana_cloud/config.yaml
+++ b/grafana_cloud/config.yaml
@@ -1,6 +1,6 @@
 name: "Grafana Cloud"
 description: "Send metrics & logs to Grafana Cloud"
-version: "0.2.1"
+version: "0.2.2"
 slug: "grafana_cloud"
 init: false
 arch:

--- a/grafana_cloud/rootfs/config.alloy
+++ b/grafana_cloud/rootfs/config.alloy
@@ -1,7 +1,7 @@
 import.git "grafana_cloud" {
   repository = "https://github.com/grafana/alloy-modules.git"
   path = "modules/cloud/grafana/cloud/module.alloy"
-  revision = "9c838a1fd98962edf80393cf5f5f94bbb416ecc1" # v0.2.11
+  revision = "9c838a1fd98962edf80393cf5f5f94bbb416ecc1" // v0.2.11
   pull_frequency = "0s"
 }
 

--- a/grafana_cloud/rootfs/config.alloy
+++ b/grafana_cloud/rootfs/config.alloy
@@ -6,8 +6,8 @@ import.git "grafana_cloud" {
 }
 
 grafana_cloud.stack "receivers" {
-  stack_name = env("STACK_NAME")
-  token = env("ACCESS_TOKEN")
+  stack_name = sys.env("STACK_NAME")
+  token = sys.env("ACCESS_TOKEN")
 }
 
 logging {
@@ -20,7 +20,7 @@ loki.process "alloy" {
   forward_to = [grafana_cloud.stack.receivers.logs]
   stage.static_labels {
     values = {
-      instance = env("INSTANCE_NAME"),
+      instance = sys.env("INSTANCE_NAME"),
     }
   }
 }
@@ -30,10 +30,10 @@ prometheus.scrape "alloy" {
   targets = [
     {
       "__address__" = "0.0.0.0:80",
-      "instance" = env("INSTANCE_NAME"),
+      "instance" = sys.env("INSTANCE_NAME"),
     },
   ]
-  scrape_interval = env("SCRAPE_INTERVAL")
+  scrape_interval = sys.env("SCRAPE_INTERVAL")
 }
 
 loki.source.file "homeassistant" {
@@ -41,7 +41,7 @@ loki.source.file "homeassistant" {
   targets = [
     {
       "__path__" = "/homeassistant/home-assistant.log",
-      "instance" = env("INSTANCE_NAME"),
+      "instance" = sys.env("INSTANCE_NAME"),
       "component" = "homeassistant",
     },
   ]
@@ -60,11 +60,11 @@ prometheus.scrape "homeassistant" {
   targets = [
     {
       "__address__" = "supervisor:80",
-      "instance" = env("INSTANCE_NAME"),
+      "instance" = sys.env("INSTANCE_NAME"),
     },
   ]
-  scrape_interval = env("SCRAPE_INTERVAL")
+  scrape_interval = sys.env("SCRAPE_INTERVAL")
   metrics_path = "/core/api/prometheus"
-  bearer_token = env("SUPERVISOR_TOKEN")
+  bearer_token = sys.env("SUPERVISOR_TOKEN")
   scheme = "http"
 }


### PR DESCRIPTION
## Problem

Two issues shipped in 0.2.1:

1. **Addon fails to start.** The `revision` pin comment in `config.alloy` used `#`, which Alloy syntax does not support:

```
Error: /config.alloy:4:57: illegal character U+0023 '#'
Error: could not perform the initial load successfully
```

2. **Lint workflow fails on `main`.** The HA addon linter rejects `@sha256:` digest suffixes in `build_from`:

```
{'amd64': 'ghcr.io/home-assistant/amd64-base:3.24@sha256:db83d263...', ...} is not valid under any of the given schemas
```

Neither was caught before release because nothing in CI validated `config.alloy`.

## Solution

- Use `//` for the comment in `config.alloy` -- Alloy's comment syntax.
- Drop the digest pins from `build.yaml`. The `Dockerfile` keeps its own `@sha256:` pin, which is what CI builds from; `build.yaml` is only consulted by Supervisor local builds.
- Replace the 9 deprecated `env()` calls with `sys.env()`.
- Add a **Validate Alloy config** job to the lint workflow running `alloy validate` against each addon's `config.alloy`, using the Alloy version read from that addon's `Dockerfile` so there is no second place to bump.

Bumps addon version to 0.2.2.

## Why `sys.env` and `validate` together

`alloy validate` is strictly stronger than `alloy fmt` -- it catches unknown component names and broken references, not just parse errors. It could not be used while the config called `env()`, because `validate` treats deprecation warnings as failures and offers no flag to downgrade them. Migrating to `sys.env()` unblocks it. `env()` still works and is not slated for removal before a 2.0, so this is forward-looking rather than urgent, but it costs nothing and buys the stronger check.

No compatibility concern: the config is only ever evaluated by the Alloy binary bundled in the same image, which is pinned to v1.19.2 in the `Dockerfile`.

## Test plan

- [x] `alloy validate` exits 0 with zero warnings on the migrated config
- [x] Check fails (exit 1) on all three regression classes: the `#` comment that broke 0.2.1, an unknown component name, and a broken reference
- [x] Local `docker build --build-arg BUILD_ARCH=amd64` succeeds
- [x] `grafana-alloy` binary is executable (`-rwxr-xr-x`) and runs
- [x] `Lint add-on grafana_cloud` passes in CI
- [x] `Validate Alloy config grafana_cloud` passes in CI
- [x] `Build amd64 image` / `Build aarch64 image` pass in CI